### PR TITLE
fix: Limit number of vegeta workers, regularly produce some metrics in the background [INGEST-1148]

### DIFF
--- a/web_server/master.go
+++ b/web_server/master.go
@@ -196,6 +196,7 @@ func masterStopHandler(ctx *gin.Context) {
 	log.Info().Msg("stop handler called")
 	var workerUrls = getWorkers()
 	var client = getDefaultHttpClient()
+	globalMasterMetrics.desiredRate = 0
 	for _, worker := range workerUrls {
 		go func(workerUrl string) {
 			var stopUrl = fmt.Sprintf("%s/stop/", workerUrl)
@@ -232,8 +233,8 @@ func masterCommandHandler(statsdClient *statsd.Client, ctx *gin.Context) {
 	globalMasterMetrics.desiredRate = freq
 	go ForwardAttack(params) // no need to wait for sending it to clients
 	ctx.JSON(http.StatusOK, "Attack forwarded to workers")
-
 }
+
 func masterRegisterHandlerFactory(statsdClient string, targetUrl string) func(*gin.Context) {
 	return func(ctx *gin.Context) {
 		var workerReq registerWorkerRequest

--- a/web_server/worker.go
+++ b/web_server/worker.go
@@ -206,7 +206,7 @@ func worker(targetUrl string, statsdAddr string, configParams configParams, para
 		default:
 			if targeter != nil {
 				rate := vegeta.Rate{Freq: params.NumMessages, Per: params.Per}
-				attacker := vegeta.NewAttacker(vegeta.Timeout(time.Millisecond*500), vegeta.Redirects(0), vegeta.MaxWorkers(5000))
+				attacker := vegeta.NewAttacker(vegeta.Timeout(time.Millisecond*500), vegeta.Redirects(0), vegeta.MaxWorkers(1000))
 				for res := range attacker.Attack(targeter, rate, params.AttackDuration, params.Description) {
 					vegetaStats.Add(res)
 					if statsdClient != nil {


### PR DESCRIPTION
Internal Vegeta metrics are currently produces to stdout, as a next step will also start sending them to statsd.