### PR TITLE
feat: Emit a metric for "invalid" runs

### DIFF
--- a/utils/main.go
+++ b/utils/main.go
@@ -204,9 +204,3 @@ func GetStatsd(statsdAddr string) *statsd.Client {
 	log.Info().Msgf("Registered with statsd server at: %s", statsdAddr)
 	return client
 }
-
-// DeepCopy deepcopies a to b using json marshaling
-func DeepCopy(a interface{}, b interface{}) {
-	bytes, _ := json.Marshal(a)
-	json.Unmarshal(bytes, b)
-}


### PR DESCRIPTION
The new `vegeta.data_invalid` metric will be emitted when we detect that the current success rate is visibly lower than the overall rate of the requests. 
This also sends a few other metrics gathered by Vegeta.