### PR TITLE
Support configurable parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,24 @@ soon as it is needed even when high volume is needed.
 It is important to set this parameter accurately specifically when the worker
 runs in an environment where the number of cores is limited (like k8s) or when
 it takes long to produce each requests (like large batches of data).
+
+Some tips to find the right value assuming the process to generate the request
+is CPU intensive:
+
+1.  If you are only limited by the number of cores on your machine, just set the
+    parallelism value to the number of cores.
+
+2.  If you have more specific limits (like when running in k8s), estimate or measure
+    the time it takes to produce a request. You can try by setting w to 1 and
+    messages per second to 1 then increase this last one.
+    Either you saturate the system you are testing first, or you reach a point
+    where you cannot produce faster.
+
+        * If you saturate the target first, you do not have a problem in producing
+
+    requests.
+
+        * If you saturate the producer first you know how many requests per second you
+
+    can produce from this test. The parallelism you want is the desired number
+    of request per second divided by the request per second per thread.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 Known limitations:
 
-* The framework is currently Sentry-oriented. The data generators that are currently supported are described [here](docs/TestFormat.md#tests).
-* Worker registration/keep-alive behaviour is not very robust
+- The framework is currently Sentry-oriented. The data generators that are currently supported are described [here](docs/TestFormat.md#tests).
+- Worker registration/keep-alive behaviour is not very robust
 
 ## Usage
 
@@ -15,11 +15,11 @@ For supported load generators and parameter details -- see [here](docs/TestForma
 
 [More information about the general architecture and writing tests.](docs/Writing-tests.md)
 
-
 The load tester can run in a few modes:
-* as a master process controlling worker load testers
-* as a worker load tester
-* as a standalone load tester ( this is achieved by running it in worker mode without providing a master url)
+
+- as a master process controlling worker load testers
+- as a worker load tester
+- as a standalone load tester ( this is achieved by running it in worker mode without providing a master url)
 
 Global usage
 
@@ -53,9 +53,11 @@ Available Commands:
   worker      Run a worker, that waits for commands from a server
 
 Flags:
+  -h, --help                   help for run
   -p, --port string            port to listen to (default "8000")
       --statsd-server string   ip:port for the statsd server
   -t, --target-url string      target URL for the attack
+  -w, --workers int            threads to use to build load (default 10)
 
 Global Flags:
       --color           Use color (only for console output).
@@ -63,7 +65,6 @@ Global Flags:
       --log string      Log level: trace, info, warn, (error), fatal, panic (default "info")
 
 Use "go-load-tester run [command] --help" for more information about a command.
-
 ```
 
 ### Master Mode
@@ -105,3 +106,13 @@ Global Flags:
   -t, --target-url string      target URL for the attack
 
 ```
+
+## Parallelism
+
+The worker takes `-w` parameters that defines the level of parallelism used to
+produce the requests for the target. This allows us to have a request ready as
+soon as it is needed even when high volume is needed.
+
+It is important to set this parameter accurately specifically when the worker
+runs in an environment where the number of cores is limited (like k8s) or when
+it takes long to produce each requests (like large batches of data).

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2021 Sentry
-
 */
 package cmd
 
@@ -12,6 +11,7 @@ type runCliParams struct {
 	port       string
 	targetUrl  string
 	statsdAddr string
+	workers    int
 }
 
 var runConfig runCliParams
@@ -29,6 +29,7 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 
 	runCmd.PersistentFlags().StringVarP(&runConfig.port, "port", "p", "8000", "port to listen to")
+	runCmd.PersistentFlags().IntVarP(&runConfig.workers, "workers", "w", 1, "threads to use to build load")
 	runCmd.PersistentFlags().StringVarP(&runConfig.targetUrl, "target-url", "t", "", "target URL for the attack")
 	runCmd.PersistentFlags().StringVar(&runConfig.statsdAddr, "statsd-server", "", "ip:port for the statsd server")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,7 +29,7 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 
 	runCmd.PersistentFlags().StringVarP(&runConfig.port, "port", "p", "8000", "port to listen to")
-	runCmd.PersistentFlags().IntVarP(&runConfig.workers, "workers", "w", 1, "threads to use to build load")
+	runCmd.PersistentFlags().IntVarP(&runConfig.workers, "workers", "w", 10, "threads to use to build load")
 	runCmd.PersistentFlags().StringVarP(&runConfig.targetUrl, "target-url", "t", "", "target URL for the attack")
 	runCmd.PersistentFlags().StringVar(&runConfig.statsdAddr, "statsd-server", "", "ip:port for the statsd server")
 }

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2021 Sentry
-
 */
 package cmd
 
@@ -37,7 +36,7 @@ var workerCmd = &cobra.Command{
 			log.Info().Msgf("No file found at %s using the default RandomProjectProvider", fileProjectPath)
 		}
 
-		web_server.RunWorkerWebServer(runConfig.port, runConfig.targetUrl, runWorkerParams.masterUrl, runConfig.statsdAddr)
+		web_server.RunWorkerWebServer(runConfig.port, runConfig.targetUrl, runWorkerParams.masterUrl, runConfig.statsdAddr, runConfig.workers)
 	},
 }
 

--- a/push-image.sh
+++ b/push-image.sh
@@ -17,6 +17,6 @@ IMAGE="${REPO}/go-load-tester"
 TAG=$(git rev-parse HEAD)
 
 echo "Pushing ${IMAGE}:${TAG}"
-docker build -t $IMAGE:$TAG .
+docker build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push $IMAGE:$TAG

--- a/push-image.sh
+++ b/push-image.sh
@@ -11,9 +11,12 @@ set -euxo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR
 
-IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/go-load-tester"
+REPO=${1:-europe-west3-docker.pkg.dev/sentry-st-testing/main}
+
+IMAGE="${REPO}/go-load-tester"
 TAG=$(git rev-parse HEAD)
 
+echo "Pushing ${IMAGE}:${TAG}"
 docker build -t $IMAGE:$TAG .
 
 docker push $IMAGE:$TAG


### PR DESCRIPTION
Producing large requests (like Clickhouse batches) takes time.
Running the worker in Kubernetes implies having a set number
of cores available. 

This introduces the need to be able to configure the maximum
number of threads used to produce requests to have requests
ready when needed. 

The longer it takes to build  request the higher the parallelism.
The lower the number of cores the lower the parallelism in
order not to be throttled.

This also fixes the push-image script not to have the 
artifact registry hardcoded.

