### PR TITLE
Add Clickhouse Insert Test

### DIFF
--- a/tests/clickhouseInsert.go
+++ b/tests/clickhouseInsert.go
@@ -1,0 +1,111 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/getsentry/go-load-tester/tests/dataproviders"
+	"github.com/rs/zerolog/log"
+	vegeta "github.com/tsenart/vegeta/lib"
+)
+
+// Contains  functionality for generating Session load tests
+
+type ClickhouseInsertLoadTester struct {
+	url         string
+	queryParams dataproviders.ClickhouseInsertJob
+
+	batchBuilder dataproviders.BatchBuilder
+}
+
+func newClickhouseInsertLoadTester(url string, rawClickhouseQueryParams json.RawMessage) LoadTester {
+	var jsonClickhouseQueryParams dataproviders.ClickhouseInsertJobRaw
+	err := json.Unmarshal(rawClickhouseQueryParams, &jsonClickhouseQueryParams)
+	if err != nil {
+		log.Error().Err(err).Msgf("invalid Clickhouse Insert params received\nraw data\n%s",
+			rawClickhouseQueryParams)
+	}
+
+	var clickhouseQueryParams dataproviders.ClickhouseInsertJob
+	err = jsonClickhouseQueryParams.Into(&clickhouseQueryParams)
+	if err != nil {
+		log.Error().Err(err).Msgf("invalid Clickhouse Insert params received\nraw data")
+	}
+
+	log.Trace().Msgf("Clickhouse Insert generation for:\n%+v", clickhouseQueryParams)
+
+	return &ClickhouseInsertLoadTester{
+		url:         url,
+		queryParams: clickhouseQueryParams,
+		batchBuilder: *dataproviders.NewBatchBuilder(
+			clickhouseQueryParams.Schema,
+			uint64(clickhouseQueryParams.BatchSize),
+		),
+	}
+}
+
+func (slt *ClickhouseInsertLoadTester) GetTargeter() (vegeta.Targeter, uint64) {
+	return func(tgt *vegeta.Target) error {
+		if tgt == nil {
+			return vegeta.ErrNilTarget
+		}
+
+		tgt.Method = "POST"
+		log.Trace().Msgf("%v Preparing batch", time.Now().Format("2006-01-02T15:04:05"))
+		batch := slt.batchBuilder.BuildBatch()
+		var buffer bytes.Buffer
+		log.Trace().Msgf("%v Batch Full", time.Now().Format("2006-01-02T15:04:05"))
+		for _, row := range batch {
+			json_row, err := json.Marshal(row)
+			if err != nil {
+				log.Error().Err(err).Msgf("Failure in marshalling data")
+			}
+			buffer.Write(json_row)
+			buffer.WriteByte('\n')
+		}
+		log.Trace().Msgf("%v Batch Serialized", time.Now().Format("2006-01-02T15:04:05"))
+		args := url.QueryEscape(fmt.Sprintf("INSERT INTO %s FORMAT JSONEachRow", slt.queryParams.TableName))
+		tgt.URL = fmt.Sprintf("%s/?query=%s", slt.url, args)
+		tgt.Header = make(http.Header)
+		tgt.Header.Set("Content-Type", "application/json")
+		tgt.Header.Set("Accept-Encoding", "gzip,deflate")
+		tgt.Body = buffer.Bytes()
+		return nil
+	}, 0
+}
+
+func (slt *ClickhouseInsertLoadTester) ProcessResult(_ *vegeta.Result, _ uint64) {
+	return // nothing to do
+}
+
+func clickhouseInsertLoadSplitter(masterParams TestParams, numWorkers int) ([]TestParams, error) {
+	if numWorkers <= 0 {
+		return nil, fmt.Errorf("invalid number of workers %d need at least 1", numWorkers)
+	}
+
+	newParams := masterParams
+	newParams.Per = time.Duration(numWorkers) * masterParams.Per
+	var jsonClickhouseQueryParams dataproviders.ClickhouseInsertJobRaw
+	err := json.Unmarshal(masterParams.Params, &jsonClickhouseQueryParams)
+	if err != nil {
+		log.Error().Err(err).Msgf("invalid Clickhouse Insert params received\nraw data\n%s",
+			masterParams.Params)
+	}
+
+	retVal := make([]TestParams, 0, numWorkers)
+	for idx := 0; idx < numWorkers; idx++ {
+		jsonClickhouseQueryParams.Partitions = numWorkers
+		jsonClickhouseQueryParams.PartitionId = idx
+		newParams.Params, _ = json.Marshal(jsonClickhouseQueryParams)
+		retVal = append(retVal, newParams)
+	}
+	return retVal, nil
+}
+
+func init() {
+	RegisterTestType("clickhouseInsert", newClickhouseInsertLoadTester, clickhouseInsertLoadSplitter)
+}

--- a/tests/clickhouseInsert_test.go
+++ b/tests/clickhouseInsert_test.go
@@ -1,0 +1,64 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/getsentry/go-load-tester/tests/dataproviders"
+)
+
+func TestSplitter(t *testing.T) {
+	test_param := TestParams{
+		Name:           "my_test",
+		Description:    "my_desc",
+		TestType:       "clickhouseInsert",
+		AttackDuration: 3600,
+		NumMessages:    3600,
+		Per:            1,
+		Params: json.RawMessage(`
+		{ 
+			"batchSize": 5,
+			"tableName": "test_table_local",
+			"config": {
+				"seq": {
+					"valueType": "partitionedSequence",
+					"config": {}
+				},
+				"constStr": {
+					"valueType": "const",
+					"config": {
+						"value": "my_val"
+					}
+				}           
+			}
+		}
+		`),
+	}
+
+	result, err := clickhouseInsertLoadSplitter(test_param, 2)
+	if err != nil {
+		t.Error(fmt.Printf("split returned error %s", err))
+	}
+
+	if len(result) != 2 {
+		t.Error(fmt.Printf("Split returned wrong number of results %d", len(result)))
+	}
+
+	result1 := result[0]
+	if result1.Per != 2 {
+		t.Error(fmt.Printf("Split did not increase the Per. Actual value %d", result1.Per))
+	}
+
+	var jsonClickhouseQueryParams dataproviders.ClickhouseInsertJobRaw
+	json.Unmarshal(result1.Params, &jsonClickhouseQueryParams)
+	if jsonClickhouseQueryParams.Partitions != 2 {
+		t.Error(fmt.Printf("Partitions value did not increase. Actual value %d", jsonClickhouseQueryParams.Partitions))
+	}
+
+	result2 := result[1]
+	json.Unmarshal(result2.Params, &jsonClickhouseQueryParams)
+	if jsonClickhouseQueryParams.PartitionId != 1 {
+		t.Error(fmt.Printf("Partition id value is wrong. Actual value %d", jsonClickhouseQueryParams.PartitionId))
+	}
+}

--- a/tests/clickhouseQuery.go
+++ b/tests/clickhouseQuery.go
@@ -1,0 +1,71 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/rs/zerolog/log"
+	vegeta "github.com/tsenart/vegeta/lib"
+)
+
+// Contains  functionality for generating Session load tests
+
+type ClickhouseQueryJob struct {
+	// A random int that changes the SELECT
+	multiplier int64
+}
+
+type clickhouseQueryLoadTester struct {
+	url         string
+	queryParams ClickhouseQueryJob
+}
+
+func newClickhouseQueryLoadTester(url string, rawClickhouseQueryParams json.RawMessage) LoadTester {
+	var jsonClickhouseQueryParams ClickhouseQueryJobRaw
+	err := json.Unmarshal(rawClickhouseQueryParams, &jsonClickhouseQueryParams)
+	if err != nil {
+		log.Error().Err(err).Msgf("invalid Clickhouse Query params received\nraw data\n%s",
+			rawClickhouseQueryParams)
+	}
+
+	var clickhouseQueryParams ClickhouseQueryJob
+	jsonClickhouseQueryParams.into(&clickhouseQueryParams)
+
+	log.Trace().Msgf("Clickhouse Query generation for:\n%+v", clickhouseQueryParams)
+
+	return &clickhouseQueryLoadTester{
+		url:         url,
+		queryParams: clickhouseQueryParams,
+	}
+}
+
+func (slt *clickhouseQueryLoadTester) GetTargeter() (vegeta.Targeter, uint64) {
+	return func(tgt *vegeta.Target) error {
+		if tgt == nil {
+			return vegeta.ErrNilTarget
+		}
+
+		tgt.Method = "GET"
+		args := url.QueryEscape(fmt.Sprintf("SELECT %d;", slt.queryParams.multiplier))
+		tgt.URL = fmt.Sprintf("%s/?query=%s", slt.url, args)
+		return nil
+	}, 0
+}
+
+func (slt *clickhouseQueryLoadTester) ProcessResult(_ *vegeta.Result, _ uint64) {
+	return // nothing to do
+}
+
+type ClickhouseQueryJobRaw struct {
+	Multiplier int64 `json:"multiplier"`
+}
+
+func (raw ClickhouseQueryJobRaw) into(result *ClickhouseQueryJob) error {
+	result.multiplier = raw.Multiplier
+	return nil
+}
+
+func init() {
+	RegisterTestType("clickhouseQuery", newClickhouseQueryLoadTester, nil)
+}

--- a/tests/clickhouseQuery_test.go
+++ b/tests/clickhouseQuery_test.go
@@ -1,0 +1,22 @@
+package tests
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestUnmarshalJson(t *testing.T) {
+	jsonData := json.RawMessage(`{"multiplsier": 100}`)
+
+	loadTester := newClickhouseQueryLoadTester("http://localhost:9000", jsonData)
+	//expected := ClickhouseQueryJob{
+	//	multiplier: 100,
+	//}
+
+	if _, ok := loadTester.(*clickhouseQueryLoadTester); ok {
+
+	} else {
+		t.Error("Invalid type genrated")
+	}
+
+}

--- a/tests/clickhouseQuery_test.go
+++ b/tests/clickhouseQuery_test.go
@@ -6,12 +6,9 @@ import (
 )
 
 func TestUnmarshalJson(t *testing.T) {
-	jsonData := json.RawMessage(`{"multiplsier": 100}`)
+	jsonData := json.RawMessage(`{"multiplier": 100}`)
 
 	loadTester := newClickhouseQueryLoadTester("http://localhost:9000", jsonData)
-	//expected := ClickhouseQueryJob{
-	//	multiplier: 100,
-	//}
 
 	if _, ok := loadTester.(*clickhouseQueryLoadTester); ok {
 

--- a/tests/dataproviders/config.go
+++ b/tests/dataproviders/config.go
@@ -1,0 +1,190 @@
+package dataproviders
+
+import "fmt"
+
+type ClickhouseFieldRaw struct {
+	ValueType string                 `json:"valueType"`
+	Config    map[string]interface{} `json:"config"`
+}
+
+type ClickhouseInsertJobRaw struct {
+	BatchSize   int64                         `json:"batchSize"`
+	TableName   string                        `json:"tableName"`
+	Partitions  int                           `json:"partitions"`
+	PartitionId int                           `json:"partitionId"`
+	Config      map[string]ClickhouseFieldRaw `json:"config"`
+}
+
+func (raw ClickhouseInsertJobRaw) Into(result *ClickhouseInsertJob) error {
+	result.BatchSize = raw.BatchSize
+	result.TableName = raw.TableName
+	result.PartitionId = raw.PartitionId
+	if raw.Partitions == 0 {
+		result.Partitions = 1
+	} else {
+		result.Partitions = raw.Partitions
+	}
+	schema, err := NewStructFromConfig(raw.Config, result.Partitions, result.PartitionId)
+	if err != nil {
+		return err
+	}
+	result.Schema = *schema
+
+	return nil
+}
+
+type ClickhouseInsertJob struct {
+	// Size of each batch to build
+	BatchSize int64
+
+	TableName string
+
+	PartitionId int
+	Partitions  int
+
+	Schema StructValue
+}
+
+func NewStructFromConfig(
+	config map[string]ClickhouseFieldRaw,
+	partitions int,
+	partition_id int,
+) (*StructValue, error) {
+	ret := make(map[string]Value)
+	for key, config := range config {
+		val, err := BuildField(config, partitions, partition_id)
+		if err != nil {
+			return nil, fmt.Errorf("failed init %s, %v", key, err)
+		}
+		ret[key] = val
+	}
+
+	return NewStructValue(ret, []StructValue{}), nil
+}
+
+func BuildField(config ClickhouseFieldRaw, partitions int, partition_id int) (Value, error) {
+	value_type := config.ValueType
+
+	value_config := config.Config
+
+	switch value_type {
+	case "const":
+		value, err := NewConstFromConfig(value_config)
+		if err != nil {
+			return nil, err
+		}
+		return value, nil
+
+	case "partitionedSequence":
+		return &Sequence{
+			From: uint64(partition_id),
+			Step: uint64(partitions),
+		}, nil
+
+	case "sequence":
+		return &Sequence{
+			From: 0,
+			Step: 1,
+		}, nil
+
+	case "randomSet":
+		value, err := NewRandomSetFromConfig(value_config)
+		if err != nil {
+			return nil, err
+		}
+		return value, nil
+
+	case "sequenceSet":
+		value, err := NewSequenceSetFromConfig(value_config)
+		if err != nil {
+			return nil, err
+		}
+		return value, nil
+
+	case "timestamp":
+		value, err := NewTimestampFromConfig(value_config)
+		if err != nil {
+			return nil, err
+		}
+		return value, nil
+
+	case "uuid":
+		return &UUIDGenerator{}, nil
+
+	case "randomInt":
+		value, err := NewRandomIntegerFromConfig(value_config)
+		if err != nil {
+			return nil, err
+		}
+		return value, nil
+
+	case "randomFloat":
+		value, err := NewRandomFloatFromConfig(value_config)
+		if err != nil {
+			return nil, err
+		}
+		return value, nil
+
+	case "randomString":
+		value, err := NewRandomStringFromConfig(value_config)
+		if err != nil {
+			return nil, err
+		}
+		return value, nil
+
+	case "randomArray":
+		valueProvider, err := BuildValueProvider(
+			value_config["valueProvider"].(map[string](interface{})),
+			partitions,
+			partition_id,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		value, err := NewRandomArrayFromConfig(value_config, valueProvider)
+		if err != nil {
+			return nil, err
+		}
+		return value, nil
+
+	case "randomMap":
+		keyProvider, err := BuildValueProvider(
+			value_config["keyProvider"].(map[string](interface{})),
+			partitions,
+			partition_id,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		valueProvider, err := BuildValueProvider(
+			value_config["valueProvider"].(map[string](interface{})),
+			partitions,
+			partition_id,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		value, err := NewRandomMapFromConfig(value_config, keyProvider, valueProvider)
+		if err != nil {
+			return nil, err
+		}
+		return value, nil
+	}
+
+	return nil, fmt.Errorf("invalid type %s", value_type)
+}
+
+func BuildValueProvider(config map[string](interface{}), partitions int, partition_id int) (Value, error) {
+	providerConfig := ClickhouseFieldRaw{
+		ValueType: config["valueType"].(string),
+		Config:    config["config"].(map[string]interface{}),
+	}
+	valueProvider, err := BuildField(providerConfig, partitions, partition_id)
+	if err != nil {
+		return nil, err
+	}
+	return valueProvider, nil
+}

--- a/tests/dataproviders/config.go
+++ b/tests/dataproviders/config.go
@@ -15,7 +15,7 @@ type ClickhouseInsertJobRaw struct {
 	Config      map[string]ClickhouseFieldRaw `json:"config"`
 }
 
-func (raw ClickhouseInsertJobRaw) Into(result *ClickhouseInsertJob) error {
+func (raw *ClickhouseInsertJobRaw) Into(result *ClickhouseInsertJob) error {
 	result.BatchSize = raw.BatchSize
 	result.TableName = raw.TableName
 	result.PartitionId = raw.PartitionId

--- a/tests/dataproviders/config_test.go
+++ b/tests/dataproviders/config_test.go
@@ -1,0 +1,120 @@
+package dataproviders
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestBasicConfig(t *testing.T) {
+	config := map[string]ClickhouseFieldRaw{
+		"field1": ClickhouseFieldRaw{
+			ValueType: "const",
+			Config: map[string]interface{}{
+				"value": "my_val",
+			},
+		},
+		"field2": ClickhouseFieldRaw{
+			ValueType: "partitionedSequence",
+			Config:    map[string]interface{}{},
+		},
+		"field3": ClickhouseFieldRaw{
+			ValueType: "sequence",
+			Config:    map[string]interface{}{},
+		},
+	}
+
+	structure, err := NewStructFromConfig(config, 4, 1)
+	if err != nil {
+		t.Error(fmt.Printf("Invalid config %s", err))
+	}
+
+	row := structure.GetValue(1)
+	if row["field1"] != "my_val" {
+		t.Error(fmt.Printf("Invalid value %s", row["field1"]))
+	}
+	if row["field2"] != uint64(5) {
+		t.Error(fmt.Printf("Invalid value %d", row["field2"]))
+	}
+	if row["field3"] != uint64(1) {
+		t.Error(fmt.Printf("Invalid value %d", row["field3"]))
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	data := `{ 
+        "batchSize": 5,
+        "tableName": "test_table_local",
+        "config": {
+            "seq": {
+                "valueType": "partitionedSequence",
+                "config": {}
+            },
+            "constStr": {
+                "valueType": "const",
+                "config": {
+                    "value": "my_val"
+                }
+            },
+			"method": {
+                "valueType": "sequenceSet",
+                "config": {
+                    "alphabet": ["GET", "POST", "DELETE"]
+                }
+            },
+			"manyValues": {
+                "valueType": "randomArray",
+                "config": {
+                    "valueProvider": {
+						"valueType": "const",
+						"config": {
+							"value": "my_val"
+						}		
+					},
+					"maxSize": 5,
+					"minSize": 5
+					
+                }
+            },
+			"mapValues": {
+                "valueType": "randomMap",
+                "config": {
+                    "keyProvider": {
+						"valueType": "const",
+						"config": {
+							"value": "my_val"
+						}		
+					},
+					"valueProvider": {
+						"valueType": "const",
+						"config": {
+							"value": "my_val"
+						}		
+					},
+					"maxSize": 5,
+					"minSize": 5
+					
+                }
+            }          
+        }
+    }`
+
+	var doc ClickhouseInsertJobRaw
+	err := json.Unmarshal([]byte(data), &doc)
+	if err != nil {
+		t.Error(fmt.Printf("Error unmarshalling JSON: %s", err))
+		return
+	}
+
+	struct_config, err := NewStructFromConfig(doc.Config, 1, 0)
+	if err != nil {
+		t.Error(fmt.Printf("Invalid config: %s", err))
+		return
+	}
+	row := struct_config.GetValue(1)
+	_, ok := row["manyValues"].([](interface{}))
+	if !ok {
+		t.Error(fmt.Printf("Invalid array: %v", row))
+		return
+	}
+}

--- a/tests/dataproviders/struct.go
+++ b/tests/dataproviders/struct.go
@@ -6,7 +6,12 @@ import (
 
 type StructValue struct {
 	valueBuilders map[string]Value
-	flattened     []StructValue
+	// The flattened field is used to create data providers that produce
+	// multi column values that are then merged into the results.
+	// We may want to create values for columns that are statistically
+	// correlated, so they cannot be generated independently. This is
+	// meant to solve this problem. Though it is not implemented yet.
+	flattened []StructValue
 }
 
 func NewStructValue(

--- a/tests/dataproviders/struct.go
+++ b/tests/dataproviders/struct.go
@@ -1,0 +1,63 @@
+package dataproviders
+
+import (
+	"sync"
+)
+
+type StructValue struct {
+	valueBuilders map[string]Value
+	flattened     []StructValue
+}
+
+func NewStructValue(
+	builders map[string]Value,
+	flattened []StructValue,
+) *StructValue {
+	return &StructValue{
+		valueBuilders: builders,
+		flattened:     flattened,
+	}
+}
+
+func (structValue *StructValue) GetValue(
+	sequence uint64,
+) map[string]interface{} {
+	ret := make(map[string]interface{})
+	for key, generator := range structValue.valueBuilders {
+		ret[key] = generator.GetValue(sequence)
+	}
+	for _, generator := range structValue.flattened {
+		for key, subvalue := range generator.GetValue((sequence)) {
+			ret[key] = subvalue
+		}
+	}
+	return ret
+}
+
+type BatchBuilder struct {
+	rowBuilder StructValue
+	sequence   uint64
+	batchSize  uint64
+	lock       sync.Mutex
+}
+
+func NewBatchBuilder(rowBuilder StructValue, batchSize uint64) *BatchBuilder {
+	return &BatchBuilder{
+		rowBuilder: rowBuilder,
+		sequence:   0,
+		batchSize:  batchSize,
+	}
+}
+
+func (builder *BatchBuilder) BuildBatch() []map[string]interface{} {
+	builder.lock.Lock()
+	defer builder.lock.Unlock()
+	var ret []map[string]interface{}
+	var i uint64
+	for i = 0; i < builder.batchSize; i++ {
+		ret = append(ret, builder.rowBuilder.GetValue(builder.sequence+i))
+	}
+
+	builder.sequence += builder.batchSize
+	return ret
+}

--- a/tests/dataproviders/struct.go
+++ b/tests/dataproviders/struct.go
@@ -51,13 +51,15 @@ func NewBatchBuilder(rowBuilder StructValue, batchSize uint64) *BatchBuilder {
 
 func (builder *BatchBuilder) BuildBatch() []map[string]interface{} {
 	builder.lock.Lock()
-	defer builder.lock.Unlock()
+	var start = builder.sequence
+	builder.sequence += builder.batchSize
+	builder.lock.Unlock()
+
 	var ret []map[string]interface{}
 	var i uint64
 	for i = 0; i < builder.batchSize; i++ {
-		ret = append(ret, builder.rowBuilder.GetValue(builder.sequence+i))
+		ret = append(ret, builder.rowBuilder.GetValue(start+i))
 	}
 
-	builder.sequence += builder.batchSize
 	return ret
 }

--- a/tests/dataproviders/struct_test.go
+++ b/tests/dataproviders/struct_test.go
@@ -1,0 +1,72 @@
+package dataproviders
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestBasicMap(t *testing.T) {
+	var a Value
+	a = NewConst("bla")
+	b := NewConst(10)
+
+	structValue := NewStructValue(map[string]Value{
+		"constStr": a,
+		"constInt": b,
+		"seq":      &Sequence{},
+	}, []StructValue{})
+
+	val := structValue.GetValue(1)
+	compare := map[string]interface{}{
+		"constStr": "bla",
+		"constInt": 10,
+		"seq":      1,
+	}
+	if val["constStr"] != compare["constStr"] {
+		t.Error("Invalid value returned")
+	}
+	if val["constInt"] != compare["constInt"] {
+		t.Error("Invalid value returned")
+	}
+	if val["sequence"] != compare["sequence"] {
+		t.Error(fmt.Printf("Invalid value returned %s %s", val["seq"], compare["seq"]))
+	}
+}
+
+func TestBatch(t *testing.T) {
+	builder := NewBatchBuilder(
+		*NewStructValue(
+			map[string]Value{
+				"constStr": NewConst("bla"),
+				"seq":      &Sequence{Step: 1},
+			},
+			[]StructValue{},
+		),
+		3,
+	)
+
+	batch1 := builder.BuildBatch()
+	expected := [3]map[string]interface{}{
+		{"constStr": "bla", "seq": uint64(0)},
+		{"constStr": "bla", "seq": uint64(1)},
+		{"constStr": "bla", "seq": uint64(2)},
+	}
+	for i, val := range batch1 {
+		if !reflect.DeepEqual(val, expected[i]) {
+			t.Error(fmt.Printf("Batch 1 does not match %s %s", batch1, expected))
+		}
+	}
+
+	batch2 := builder.BuildBatch()
+	expected2 := [3]map[string]interface{}{
+		{"constStr": "bla", "seq": uint64(3)},
+		{"constStr": "bla", "seq": uint64(4)},
+		{"constStr": "bla", "seq": uint64(5)},
+	}
+	for i, val := range batch2 {
+		if !reflect.DeepEqual(val, expected2[i]) {
+			t.Error(fmt.Printf("Batch 2 does not match %s", batch2))
+		}
+	}
+}

--- a/tests/dataproviders/value.go
+++ b/tests/dataproviders/value.go
@@ -1,0 +1,366 @@
+package dataproviders
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Basic interface that produces a value
+type Value interface {
+	GetValue(sequence uint64) interface{}
+}
+
+// This value always returns the same value
+type ConstantValue struct {
+	value interface{}
+}
+
+func NewConst(
+	value interface{},
+) *ConstantValue {
+	return &ConstantValue{
+		value: value,
+	}
+}
+
+func NewConstFromConfig(config interface{}) (*ConstantValue, error) {
+	value_config, ok := config.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("config type invalid %s", value_config)
+	}
+	val, exists := value_config["value"]
+	if !exists {
+		return nil, fmt.Errorf("missing value attribute")
+	}
+	return NewConst(val), nil
+}
+
+func (constant *ConstantValue) GetValue(
+	sequence uint64,
+) interface{} {
+	return constant.value
+}
+
+// Sequence of integers given a start and step.
+type Sequence struct {
+	From uint64
+	Step uint64
+}
+
+func (seq *Sequence) GetValue(
+	sequence uint64,
+) interface{} {
+	return seq.From + seq.Step*sequence
+}
+
+// Discrete values
+type RandomSet struct {
+	alphabet []string
+}
+
+func (seq *RandomSet) GetValue(
+	sequence uint64,
+) interface{} {
+	randomIndex := rand.Intn(len(seq.alphabet))
+	return seq.alphabet[randomIndex]
+}
+
+type SequenceSet struct {
+	alphabet []string
+}
+
+func (seq *SequenceSet) GetValue(
+	sequence uint64,
+) interface{} {
+	return seq.alphabet[sequence%uint64(len(seq.alphabet))]
+}
+
+func getAlphabet(config interface{}) ([]string, error) {
+	value_config, ok := config.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("config type invalid %s", value_config)
+	}
+	val, exists := value_config["alphabet"]
+	if !exists {
+		return nil, fmt.Errorf("missing value attribute")
+	}
+
+	var alphabet [](string)
+	for _, word := range val.([](interface{})) {
+		alphabet = append(alphabet, word.(string))
+	}
+
+	return alphabet, nil
+}
+
+func NewRandomSetFromConfig(config interface{}) (*RandomSet, error) {
+	alphabet, err := getAlphabet((config))
+	if err != nil {
+		return nil, err
+	}
+	return &RandomSet{
+		alphabet: alphabet,
+	}, nil
+}
+
+func NewSequenceSetFromConfig(config interface{}) (*SequenceSet, error) {
+	alphabet, err := getAlphabet((config))
+	if err != nil {
+		return nil, err
+	}
+	return &SequenceSet{
+		alphabet: alphabet,
+	}, nil
+}
+
+// Timestamp
+type Timestamp struct {
+	format string
+}
+
+func (seq *Timestamp) GetValue(
+	sequence uint64,
+) interface{} {
+	now := time.Now()
+	return now.Format(seq.format)
+}
+
+func NewTimestampFromConfig(config interface{}) (*Timestamp, error) {
+	value_config, ok := config.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("config type invalid %s", value_config)
+	}
+	val, exists := value_config["format"]
+	if !exists {
+		return nil, fmt.Errorf("missing value attribute")
+	}
+	return &Timestamp{
+		format: val.(string),
+	}, nil
+}
+
+// UUID
+type UUIDGenerator struct{}
+
+func (seq *UUIDGenerator) GetValue(
+	sequence uint64,
+) interface{} {
+	return uuid.New()
+}
+
+// Random values
+
+type RandomInteger struct {
+	min int
+	max int
+}
+
+func NewRandomIntegerFromConfig(config interface{}) (*RandomInteger, error) {
+	value_config, ok := config.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("config type invalid %s", value_config)
+	}
+	min, exists := value_config["min"]
+	if !exists {
+		return nil, fmt.Errorf("missing min attribute")
+	}
+	max, exists := value_config["max"]
+	if !exists {
+		return nil, fmt.Errorf("missing max attribute")
+	}
+	return &RandomInteger{
+		min: int(min.(float64)),
+		max: int(max.(float64)),
+	}, nil
+}
+
+func (rnd *RandomInteger) GetValue(
+	sequence uint64,
+) interface{} {
+	if rnd.max == rnd.min {
+		return rnd.min
+	}
+	randomIndex := rand.Intn(rnd.max - rnd.min)
+	return rnd.min + randomIndex
+}
+
+type RandomFloat struct {
+	min float64
+	max float64
+}
+
+func NewRandomFloatFromConfig(config interface{}) (*RandomFloat, error) {
+	value_config, ok := config.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("config type invalid %s", value_config)
+	}
+	min, exists := value_config["min"]
+	if !exists {
+		return nil, fmt.Errorf("missing min attribute")
+	}
+	max, exists := value_config["max"]
+	if !exists {
+		return nil, fmt.Errorf("missing max attribute")
+	}
+	return &RandomFloat{
+		min: min.(float64),
+		max: max.(float64),
+	}, nil
+}
+
+func (rnd *RandomFloat) GetValue(
+	sequence uint64,
+) interface{} {
+	randomVal := rand.Float64() * (rnd.max - rnd.min)
+	return rnd.min + randomVal
+}
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func generateRandomString(length int) string {
+	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+type RandomString struct {
+	minSize int
+	maxSize int
+}
+
+func NewRandomStringFromConfig(config interface{}) (*RandomString, error) {
+	value_config, ok := config.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("config type invalid %s", value_config)
+	}
+	minSize, exists := value_config["minSize"]
+	if !exists {
+		return nil, fmt.Errorf("missing min attribute")
+	}
+	maxSize, exists := value_config["maxSize"]
+	if !exists {
+		return nil, fmt.Errorf("missing max attribute")
+	}
+	return &RandomString{
+		minSize: int(minSize.(float64)),
+		maxSize: int(maxSize.(float64)),
+	}, nil
+}
+
+func (rnd *RandomString) GetValue(
+	sequence uint64,
+) interface{} {
+	var length int
+	if rnd.maxSize != rnd.minSize {
+
+		length = rand.Intn(rnd.maxSize - rnd.minSize)
+	} else {
+		length = rnd.minSize
+	}
+
+	return generateRandomString(length)
+}
+
+// Array
+type RandomArray struct {
+	minSize       int
+	maxSize       int
+	valueProvider Value
+}
+
+func NewRandomArrayFromConfig(config interface{}, valueProvider Value) (*RandomArray, error) {
+	value_config, ok := config.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("config type invalid %s", value_config)
+	}
+	minSize, exists := value_config["minSize"]
+	if !exists {
+		return nil, fmt.Errorf("missing min attribute")
+	}
+	maxSize, exists := value_config["maxSize"]
+	if !exists {
+		return nil, fmt.Errorf("missing max attribute")
+	}
+
+	return &RandomArray{
+		minSize:       int(minSize.(float64)),
+		maxSize:       int(maxSize.(float64)),
+		valueProvider: valueProvider,
+	}, nil
+}
+
+func (rnd *RandomArray) GetValue(
+	sequence uint64,
+) interface{} {
+	var length int
+	if rnd.maxSize != rnd.minSize {
+
+		length = rand.Intn(rnd.maxSize - rnd.minSize)
+	} else {
+		length = rnd.minSize
+	}
+
+	var ret [](interface{})
+	for i := 0; i < length; i++ {
+		new_val := rnd.valueProvider.GetValue(sequence)
+		ret = append(ret, new_val)
+	}
+	return ret
+}
+
+// Map
+type RandomMap struct {
+	minSize       int
+	maxSize       int
+	keyProvider   Value
+	valueProvider Value
+}
+
+func NewRandomMapFromConfig(config interface{}, keyProvider Value, valueProvider Value) (*RandomMap, error) {
+	value_config, ok := config.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("config type invalid %s", value_config)
+	}
+	minSize, exists := value_config["minSize"]
+	if !exists {
+		return nil, fmt.Errorf("missing min attribute")
+	}
+	maxSize, exists := value_config["maxSize"]
+	if !exists {
+		return nil, fmt.Errorf("missing max attribute")
+	}
+
+	return &RandomMap{
+		minSize:       int(minSize.(float64)),
+		maxSize:       int(maxSize.(float64)),
+		keyProvider:   keyProvider,
+		valueProvider: valueProvider,
+	}, nil
+}
+
+func (rnd *RandomMap) GetValue(
+	sequence uint64,
+) interface{} {
+	var length int
+	if rnd.maxSize != rnd.minSize {
+
+		length = rand.Intn(rnd.maxSize - rnd.minSize)
+	} else {
+		length = rnd.minSize
+	}
+
+	var ret = make(map[string]interface{})
+	for i := 0; i < length; i++ {
+		new_key := rnd.keyProvider.GetValue(sequence)
+		new_val := rnd.valueProvider.GetValue(sequence)
+
+		ret[new_key.(string)] = new_val
+	}
+	return ret
+}

--- a/tests/dataproviders/value.go
+++ b/tests/dataproviders/value.go
@@ -171,6 +171,7 @@ func NewRandomIntegerFromConfig(config interface{}) (*RandomInteger, error) {
 	if !exists {
 		return nil, fmt.Errorf("missing max attribute")
 	}
+	// TODO: Figure out why I cannot use integers here.
 	return &RandomInteger{
 		min: int(min.(float64)),
 		max: int(max.(float64)),

--- a/tests/dataproviders/value_test.go
+++ b/tests/dataproviders/value_test.go
@@ -1,0 +1,66 @@
+package dataproviders
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestConstant(t *testing.T) {
+	var constant Value
+	constant = NewConst(10)
+	if constant.GetValue(1) != 10 {
+		t.Error("Invalid value returned")
+	}
+}
+
+func TestSequence(t *testing.T) {
+	var seq = Sequence{
+		From: 4,
+		Step: 2,
+	}
+	val := seq.GetValue(2)
+	if val != uint64(8) {
+		t.Error(fmt.Printf("Invalid value returned %d", val))
+	}
+}
+
+func TestRandomSet(t *testing.T) {
+	set, _ := NewRandomSetFromConfig(map[string]interface{}{
+		"alphabet": []string{"a", "b", "c"},
+	})
+	value := set.GetValue(1)
+	if !(value == "a" || value == "b" || value == "c") {
+		t.Error(fmt.Printf("Missing value %s", value))
+	}
+}
+
+func TestTimeStamp(t *testing.T) {
+	ts, _ := NewTimestampFromConfig(map[string]interface{}{
+		"format": "2006-01-02T15:04:05",
+	})
+	ts.GetValue(1)
+}
+
+func TestRandomInt(t *testing.T) {
+	ts, _ := NewRandomIntegerFromConfig(map[string]interface{}{
+		"min": 5,
+		"max": 5,
+	})
+	val := ts.GetValue(1)
+	if val != 5 {
+		t.Error(fmt.Printf("Missing value %d", val))
+	}
+}
+
+func TestRandomString(t *testing.T) {
+	val, _ := NewRandomStringFromConfig(map[string]interface{}{
+		"minSize": 5,
+		"maxSize": 5,
+	})
+
+	v := val.GetValue(1)
+	length := len(v.(string))
+	if length != 5 {
+		t.Error(fmt.Printf("Wrong length %d", length))
+	}
+}

--- a/tests/dataproviders/value_test.go
+++ b/tests/dataproviders/value_test.go
@@ -26,7 +26,7 @@ func TestSequence(t *testing.T) {
 
 func TestRandomSet(t *testing.T) {
 	set, _ := NewRandomSetFromConfig(map[string]interface{}{
-		"alphabet": []string{"a", "b", "c"},
+		"alphabet": []interface{}{"a", "b", "c"},
 	})
 	value := set.GetValue(1)
 	if !(value == "a" || value == "b" || value == "c") {
@@ -43,8 +43,8 @@ func TestTimeStamp(t *testing.T) {
 
 func TestRandomInt(t *testing.T) {
 	ts, _ := NewRandomIntegerFromConfig(map[string]interface{}{
-		"min": 5,
-		"max": 5,
+		"min": 5.0,
+		"max": 5.0,
 	})
 	val := ts.GetValue(1)
 	if val != 5 {
@@ -54,8 +54,8 @@ func TestRandomInt(t *testing.T) {
 
 func TestRandomString(t *testing.T) {
 	val, _ := NewRandomStringFromConfig(map[string]interface{}{
-		"minSize": 5,
-		"maxSize": 5,
+		"minSize": 5.0,
+		"maxSize": 5.0,
 	})
 
 	v := val.GetValue(1)

--- a/web_server/worker.go
+++ b/web_server/worker.go
@@ -281,7 +281,7 @@ func worker(targetUrl string, statsdAddr string, configParams *configParams, par
 		default:
 			if loadTester != nil {
 				rate := vegeta.Rate{Freq: params.NumMessages, Per: params.Per}
-				attacker := vegeta.NewAttacker(vegeta.Timeout(time.Millisecond*500), vegeta.Redirects(0), vegeta.MaxWorkers(1000))
+				attacker := vegeta.NewAttacker(vegeta.Timeout(time.Millisecond*500), vegeta.Redirects(0), vegeta.MaxWorkers(1))
 				targeter, seq := loadTester.GetTargeter()
 				for res := range attacker.Attack(targeter, rate, params.AttackDuration, params.Description) {
 					targeter, seq = loadTester.GetTargeter()


### PR DESCRIPTION
Adds two tests for the load testers:
- a basic clickhosue query (that only runs SELECT 1)
- an insertion test that generates syntetic load according to a config file.

The insert test produces batches (one abtch per request) and sends
them to the Clickhouse HTTP interface.

Syntetic traffic is generated by a set of `dataproviders`. They include
providers like:
- random int
- random string 
- UUID
- sequence
- etc.

A configuration file in this form is provided, that defines the table schema
and assigns a dataprovider to each column:

```
{
    "name": "my test",
    "description": "my description",
    "testType": "clickhouseInsert",
    "attackDuration": "5m",
    "numMessages": 1,
    "per": "1s",
    "params": { 
        "batchSize": 100000,
        "tableName": "test_table2_dist",
        "config": {
            "seq": {
                "valueType": "partitionedSequence",
                "config": {}
            },
            "constStr": {
                "valueType": "const",
                "config": {
                    "value": "my_val"
                }
            },
            "id": {
                "valueType": "uuid",
                "config": {}
            },
...
```
