### PR TITLE
Adding support for generating random timestamp between the given range.

### DIFF
--- a/tests/dataproviders/config.go
+++ b/tests/dataproviders/config.go
@@ -107,8 +107,8 @@ func BuildField(config ClickhouseFieldRaw, partitions int, partition_id int) (Va
 			return nil, err
 		}
 		return value, nil
-	
-	case "randomtimestamp":
+
+	case "randomTimestamp":
 		value, err := NewRandomTimestampFromConfig(value_config)
 		if err != nil {
 			return nil, err

--- a/tests/dataproviders/config.go
+++ b/tests/dataproviders/config.go
@@ -107,6 +107,13 @@ func BuildField(config ClickhouseFieldRaw, partitions int, partition_id int) (Va
 			return nil, err
 		}
 		return value, nil
+	
+	case "randomtimestamp":
+		value, err := NewRandomTimestampFromConfig(value_config)
+		if err != nil {
+			return nil, err
+		}
+		return value, nil
 
 	case "uuid":
 		return &UUIDGenerator{}, nil

--- a/tests/dataproviders/value.go
+++ b/tests/dataproviders/value.go
@@ -142,6 +142,55 @@ func NewTimestampFromConfig(config interface{}) (*Timestamp, error) {
 	}, nil
 }
 
+// RandomTimestamp
+type RandomTimestamp struct {
+    start  time.Time
+    end    time.Time
+    format string
+}
+
+func (rt *RandomTimestamp) GetValue() interface{} {
+    duration := rt.end.Sub(rt.start)
+    randomDuration := time.Duration(rand.Int63n(int64(duration)))
+    randomTime := rt.start.Add(randomDuration)
+    return randomTime.Format(rt.format)
+}
+
+func NewRandomTimestampFromConfig(config interface{}) (*RandomTimestamp, error) {
+    valueConfig, ok := config.(map[string]interface{})
+    if !ok {
+        return nil, fmt.Errorf("config type invalid %s", valueConfig)
+    }
+    startVal, exists := valueConfig["start"]
+    if !exists {
+        return nil, fmt.Errorf("missing start attribute")
+    }
+    endVal, exists := valueConfig["end"]
+    if !exists {
+        return nil, fmt.Errorf("missing end attribute")
+    }
+    formatVal, exists := valueConfig["format"]
+    if !exists {
+        return nil, fmt.Errorf("missing format attribute")
+    }
+
+    format := formatVal.(string)
+    start, err := time.Parse(format, startVal.(string))
+    if err != nil {
+        return nil, fmt.Errorf("invalid start time format: %v", err)
+    }
+    end, err := time.Parse(format, endVal.(string))
+    if err != nil {
+        return nil, fmt.Errorf("invalid end time format: %v", err)
+    }
+
+    return &RandomTimestamp{
+        start:  start,
+        end:    end,
+        format: format,
+    }, nil
+}
+
 // UUID
 type UUIDGenerator struct{}
 

--- a/tests/dataproviders/value.go
+++ b/tests/dataproviders/value.go
@@ -149,7 +149,7 @@ type RandomTimestamp struct {
     format string
 }
 
-func (rt *RandomTimestamp) GetValue() interface{} {
+func (rt *RandomTimestamp) GetValue(sequence uint64,) interface{} {
     duration := rt.end.Sub(rt.start)
     randomDuration := time.Duration(rand.Int63n(int64(duration)))
     randomTime := rt.start.Add(randomDuration)

--- a/tests/dataproviders/value_test.go
+++ b/tests/dataproviders/value_test.go
@@ -3,6 +3,7 @@ package dataproviders
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestConstant(t *testing.T) {
@@ -39,6 +40,38 @@ func TestTimeStamp(t *testing.T) {
 		"format": "2006-01-02T15:04:05",
 	})
 	ts.GetValue(1)
+}
+
+func TestRandomTimestamp(t *testing.T) {
+    config := map[string]interface{}{
+        "start":  "2023-01-01T00:00:00",
+        "end":    "2023-12-31T23:59:59",
+        "format": "2006-01-02T15:04:05",
+    }
+
+    randomTimestamp, err := NewRandomTimestampFromConfig(config)
+    if err != nil {
+        t.Fatalf("Error initializing RandomTimestamp: %v", err)
+    }
+
+    randomTimeStr := randomTimestamp.GetValue().(string)
+    randomTime, err := time.Parse("2006-01-02T15:04:05", randomTimeStr)
+    if err != nil {
+        t.Fatalf("Error parsing random timestamp: %v", err)
+    }
+
+    startTime, err := time.Parse("2006-01-02T15:04:05", config["start"].(string))
+    if err != nil {
+        t.Fatalf("Error parsing start time: %v", err)
+    }
+    endTime, err := time.Parse("2006-01-02T15:04:05", config["end"].(string))
+    if err != nil {
+        t.Fatalf("Error parsing end time: %v", err)
+    }
+
+    if randomTime.Before(startTime) || randomTime.After(endTime) {
+        t.Errorf("Generated timestamp %v is out of range [%v, %v]", randomTime, startTime, endTime)
+    }
 }
 
 func TestRandomInt(t *testing.T) {

--- a/tests/dataproviders/value_test.go
+++ b/tests/dataproviders/value_test.go
@@ -54,7 +54,7 @@ func TestRandomTimestamp(t *testing.T) {
         t.Fatalf("Error initializing RandomTimestamp: %v", err)
     }
 
-    randomTimeStr := randomTimestamp.GetValue().(string)
+    randomTimeStr := randomTimestamp.GetValue(1).(string)
     randomTime, err := time.Parse("2006-01-02T15:04:05", randomTimeStr)
     if err != nil {
         t.Fatalf("Error parsing random timestamp: %v", err)


### PR DESCRIPTION
Implementing a new type called 'random timestamp' to generate random timestamp values by specifying a configuration with a start and end time range, along with the desired format.
    
    "timestamp": {
     "valueType": "randomtimestamp",
     "config": {
                "start":  "2023-01-01T00:00:00",
                "end":    "2023-12-31T23:59:59",
                "format": "2006-01-02T15:04:05",
                }
    }