### PR TITLE
feat(value): sequential timestamp

### DIFF
--- a/tests/dataproviders/config.go
+++ b/tests/dataproviders/config.go
@@ -115,6 +115,13 @@ func BuildField(config ClickhouseFieldRaw, partitions int, partition_id int) (Va
 		}
 		return value, nil
 
+	case "sequentialTimestamp":
+		value, err := NewSequentialTimestampFromConfig(value_config)
+		if err != nil {
+			return nil, err
+		}
+		return value, nil
+
 	case "uuid":
 		return &UUIDGenerator{}, nil
 

--- a/tests/dataproviders/value.go
+++ b/tests/dataproviders/value.go
@@ -144,51 +144,98 @@ func NewTimestampFromConfig(config interface{}) (*Timestamp, error) {
 
 // RandomTimestamp
 type RandomTimestamp struct {
-    start  time.Time
-    end    time.Time
-    format string
+	start  time.Time
+	end    time.Time
+	format string
 }
 
-func (rt *RandomTimestamp) GetValue(sequence uint64,) interface{} {
-    duration := rt.end.Sub(rt.start)
-    randomDuration := time.Duration(rand.Int63n(int64(duration)))
-    randomTime := rt.start.Add(randomDuration)
-    return randomTime.Format(rt.format)
+func (rt *RandomTimestamp) GetValue(sequence uint64) interface{} {
+	duration := rt.end.Sub(rt.start)
+	randomDuration := time.Duration(rand.Int63n(int64(duration)))
+	randomTime := rt.start.Add(randomDuration)
+	return randomTime.Format(rt.format)
 }
 
 func NewRandomTimestampFromConfig(config interface{}) (*RandomTimestamp, error) {
-    valueConfig, ok := config.(map[string]interface{})
-    if !ok {
-        return nil, fmt.Errorf("config type invalid %s", valueConfig)
-    }
-    startVal, exists := valueConfig["start"]
-    if !exists {
-        return nil, fmt.Errorf("missing start attribute")
-    }
-    endVal, exists := valueConfig["end"]
-    if !exists {
-        return nil, fmt.Errorf("missing end attribute")
-    }
-    formatVal, exists := valueConfig["format"]
-    if !exists {
-        return nil, fmt.Errorf("missing format attribute")
-    }
+	valueConfig, ok := config.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("config type invalid %s", valueConfig)
+	}
+	startVal, exists := valueConfig["start"]
+	if !exists {
+		return nil, fmt.Errorf("missing start attribute")
+	}
+	endVal, exists := valueConfig["end"]
+	if !exists {
+		return nil, fmt.Errorf("missing end attribute")
+	}
+	formatVal, exists := valueConfig["format"]
+	if !exists {
+		return nil, fmt.Errorf("missing format attribute")
+	}
 
-    format := formatVal.(string)
-    start, err := time.Parse(format, startVal.(string))
-    if err != nil {
-        return nil, fmt.Errorf("invalid start time format: %v", err)
-    }
-    end, err := time.Parse(format, endVal.(string))
-    if err != nil {
-        return nil, fmt.Errorf("invalid end time format: %v", err)
-    }
+	format := formatVal.(string)
+	start, err := time.Parse(format, startVal.(string))
+	if err != nil {
+		return nil, fmt.Errorf("invalid start time format: %v", err)
+	}
+	end, err := time.Parse(format, endVal.(string))
+	if err != nil {
+		return nil, fmt.Errorf("invalid end time format: %v", err)
+	}
 
-    return &RandomTimestamp{
-        start:  start,
-        end:    end,
-        format: format,
-    }, nil
+	return &RandomTimestamp{
+		start:  start,
+		end:    end,
+		format: format,
+	}, nil
+}
+
+// SequentialTimestamp
+type SequentialTimestamp struct {
+	start  time.Time
+	step   time.Duration
+	format string
+}
+
+func (seq *SequentialTimestamp) GetValue(sequence uint64) interface{} {
+	timestamp := seq.start.Add(seq.step * time.Duration(sequence))
+	return timestamp.Format(seq.format)
+}
+
+func NewSequentialTimestampFromConfig(config interface{}) (*SequentialTimestamp, error) {
+	valueConfig, ok := config.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("config type invalid %s", valueConfig)
+	}
+	startVal, exists := valueConfig["start"]
+	if !exists {
+		return nil, fmt.Errorf("missing start attribute")
+	}
+	stepVal, exists := valueConfig["step"]
+	if !exists {
+		return nil, fmt.Errorf("missing step attribute")
+	}
+	formatVal, exists := valueConfig["format"]
+	if !exists {
+		return nil, fmt.Errorf("missing format attribute")
+	}
+
+	format := formatVal.(string)
+	start, err := time.Parse(format, startVal.(string))
+	if err != nil {
+		return nil, fmt.Errorf("invalid start time format: %v", err)
+	}
+	stepValDuration, err := time.ParseDuration(stepVal.(string))
+	if err != nil {
+		return nil, fmt.Errorf("invalid step type (should be time.Duration): %v", stepVal)
+	}
+
+	return &SequentialTimestamp{
+		start:  start,
+		step:   stepValDuration,
+		format: format,
+	}, nil
 }
 
 // UUID

--- a/tests/dataproviders/value_test.go
+++ b/tests/dataproviders/value_test.go
@@ -43,35 +43,59 @@ func TestTimeStamp(t *testing.T) {
 }
 
 func TestRandomTimestamp(t *testing.T) {
-    config := map[string]interface{}{
-        "start":  "2023-01-01T00:00:00",
-        "end":    "2023-12-31T23:59:59",
-        "format": "2006-01-02T15:04:05",
-    }
+	config := map[string]interface{}{
+		"start":  "2023-01-01T00:00:00",
+		"end":    "2023-12-31T23:59:59",
+		"format": "2006-01-02T15:04:05",
+	}
 
-    randomTimestamp, err := NewRandomTimestampFromConfig(config)
-    if err != nil {
-        t.Fatalf("Error initializing RandomTimestamp: %v", err)
-    }
+	randomTimestamp, err := NewRandomTimestampFromConfig(config)
+	if err != nil {
+		t.Fatalf("Error initializing RandomTimestamp: %v", err)
+	}
 
-    randomTimeStr := randomTimestamp.GetValue(1).(string)
-    randomTime, err := time.Parse("2006-01-02T15:04:05", randomTimeStr)
-    if err != nil {
-        t.Fatalf("Error parsing random timestamp: %v", err)
-    }
+	randomTimeStr := randomTimestamp.GetValue(1).(string)
+	randomTime, err := time.Parse("2006-01-02T15:04:05", randomTimeStr)
+	if err != nil {
+		t.Fatalf("Error parsing random timestamp: %v", err)
+	}
 
-    startTime, err := time.Parse("2006-01-02T15:04:05", config["start"].(string))
-    if err != nil {
-        t.Fatalf("Error parsing start time: %v", err)
-    }
-    endTime, err := time.Parse("2006-01-02T15:04:05", config["end"].(string))
-    if err != nil {
-        t.Fatalf("Error parsing end time: %v", err)
-    }
+	startTime, err := time.Parse("2006-01-02T15:04:05", config["start"].(string))
+	if err != nil {
+		t.Fatalf("Error parsing start time: %v", err)
+	}
+	endTime, err := time.Parse("2006-01-02T15:04:05", config["end"].(string))
+	if err != nil {
+		t.Fatalf("Error parsing end time: %v", err)
+	}
 
-    if randomTime.Before(startTime) || randomTime.After(endTime) {
-        t.Errorf("Generated timestamp %v is out of range [%v, %v]", randomTime, startTime, endTime)
-    }
+	if randomTime.Before(startTime) || randomTime.After(endTime) {
+		t.Errorf("Generated timestamp %v is out of range [%v, %v]", randomTime, startTime, endTime)
+	}
+}
+
+func TestSequentialTimestamp(t *testing.T) {
+	baseTime := time.Now().UTC()
+	config := map[string]interface{}{
+		"start":  baseTime.Format(time.RFC3339Nano),
+		"step":   "1µs",
+		"format": time.RFC3339Nano,
+	}
+
+	sequentialTimestamp, err := NewSequentialTimestampFromConfig(config)
+	if err != nil {
+		t.Fatalf("Error initializing SequentialTimestamp: %v", err)
+	}
+	v0 := sequentialTimestamp.GetValue(0).(string)
+	v1 := sequentialTimestamp.GetValue(1).(string)
+
+	if !(v0 == baseTime.Format(time.RFC3339Nano)) {
+		t.Error("0th element of sequence should equal baseTime")
+	}
+
+	if !(v1 == baseTime.Add(time.Microsecond).Format(time.RFC3339Nano)) {
+		t.Error("1st element of sequence should equal baseTime + 1µs")
+	}
 }
 
 func TestRandomInt(t *testing.T) {


### PR DESCRIPTION
A new value type that emits a timestamp that increases at a predictable rate (`step`). I want to key a table by a timestamp and have those timestamps land at consistent times.

note: I think the RandomTimestamp functionality was submitted with non-standard Go formatting and `go fmt` automatically rerendered it when I edited the file. I can submit a separate PR with just `go fmt` changes if we care